### PR TITLE
Added basic linting functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+out
+node_modules
+.vscode-test/
+.vsix

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "files.exclude": {
+        "out": false // set this to true to hide the "out" folder with the compiled JS files
+    },
+    "search.exclude": {
+        "out": true // set this to false to include "out" folder in search results
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "watch",
+            "problemMatcher": "$tsc-watch",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "never"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -10,11 +10,15 @@
         "url": "https://github.com/zig-lang/vscode-zig"
     },
     "engines": {
-        "vscode": "*"
+        "vscode": "^1.17.0"
     },
     "categories": [
         "Languages"
     ],
+    "activationEvents": [
+        "onLanguage:zig"
+    ],
+    "main": "./out/extension",
     "contributes": {
         "languages": [{
             "id": "zig",
@@ -26,5 +30,18 @@
             "scopeName": "source.zig",
             "path": "./syntaxes/zig.tmLanguage.json"
         }]
+    },
+    "scripts": {
+        "vscode:prepublish": "npm run compile",
+        "compile": "tsc -p ./",
+        "watch": "tsc -watch -p ./",
+        "postinstall": "node ./node_modules/vscode/bin/install",
+        "test": "npm run compile && node ./node_modules/vscode/bin/test"
+    },
+    "devDependencies": {
+        "typescript": "^2.5.3",
+        "vscode": "^1.1.5",
+        "@types/node": "^7.0.43",
+        "@types/mocha": "^2.2.42"
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,7 @@
+import * as vscode from 'vscode';
+
+export function activate(context: vscode.ExtensionContext) {
+}
+
+export function deactivate() {
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,11 @@
+'use strict';
 import * as vscode from 'vscode';
+import ZigCompilerProvider from './zigCompilerProvider';
 
 export function activate(context: vscode.ExtensionContext) {
+    let compiler = new ZigCompilerProvider();
+    compiler.activate(context.subscriptions);
+    vscode.languages.registerCodeActionsProvider('zig', compiler);
 }
 
 export function deactivate() {

--- a/src/zigCompilerProvider.ts
+++ b/src/zigCompilerProvider.ts
@@ -1,0 +1,69 @@
+'use strict';
+
+import * as path from 'path';
+import * as cp from 'child_process';
+import * as vscode from 'vscode';
+
+export default class ZigCompilerProvider implements vscode.CodeActionProvider {
+    private diagnosticCollection: vscode.DiagnosticCollection;
+    
+	public activate(subscriptions: vscode.Disposable[]) {
+		subscriptions.push(this);
+		this.diagnosticCollection = vscode.languages.createDiagnosticCollection();
+
+		vscode.workspace.onDidOpenTextDocument(this.doCompile, this, subscriptions);
+		vscode.workspace.onDidCloseTextDocument((textDocument)=> {
+			this.diagnosticCollection.delete(textDocument.uri);
+		}, null, subscriptions);
+
+		vscode.workspace.onDidSaveTextDocument(this.doCompile, this);
+
+		// Hlint all open haskell documents
+		vscode.workspace.textDocuments.forEach(this.doCompile, this);
+	}
+
+	public dispose(): void {
+		this.diagnosticCollection.clear();
+		this.diagnosticCollection.dispose();
+	}
+
+    public provideCodeActions(document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Command[]> {
+        throw new Error("Method not implemented.");
+    }
+	
+	private doCompile(textDocument: vscode.TextDocument) {
+		if (textDocument.languageId !== 'zig') {
+			return;
+		}
+		
+		let decoded = ''
+		let diagnostics: vscode.Diagnostic[] = [];
+
+		let childProcess = cp.spawn('zig', [ 'build-exe', textDocument.fileName ], undefined);
+		if (childProcess.pid) {
+			childProcess.stderr.on('data', (data: Buffer) => {
+				decoded += data;
+			});
+			childProcess.stdout.on('end', () => {
+                let regex = /(.*):(\d*):(\d*):([^:]*):(.*)/g;
+                for (let match = regex.exec(decoded); match; 
+                     match = regex.exec(decoded)) 
+                {
+                    let path    = match[1];
+                    let line    = parseInt(match[2]) - 1;
+                    let column  = parseInt(match[3]) - 1;
+                    let type    = match[4];
+                    let message = match[5];
+
+					let severity = type.trim().toLowerCase() === "error" ? vscode.DiagnosticSeverity.Error : vscode.DiagnosticSeverity.Warning;
+					let range = new vscode.Range(line, column, 
+                                                 line, column + 1);
+					let diagnostic = new vscode.Diagnostic(range, message, severity);
+					diagnostics.push(diagnostic);
+                }
+                    
+                this.diagnosticCollection.set(textDocument.uri, diagnostics);
+			});
+		}
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "outDir": "out",
+        "lib": [
+            "es6"
+        ],
+        "sourceMap": true,
+        "rootDir": "src"
+    },
+    "exclude": [
+        "node_modules",
+        ".vscode-test"
+    ]
+}


### PR DESCRIPTION
It's not really feature complete but it is something to build on.
Known issues to deal with:
- Underline entire error instead of only first char
- Check files without generating output files (We probably need a `zig check` or `zig build-lib -o "temp_path/to/output"` for this to work)